### PR TITLE
WIP: Access control, add teams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ temp/
 ts-node*/
 .editorconfig
 .env
+.env.k8s

--- a/src/common/access.ts
+++ b/src/common/access.ts
@@ -6,19 +6,30 @@
  */
 
 import { Permissioned, Access } from '../model/entity/permissioned/base';
+import { User } from '../model/user';
 
-export const isAllowedToUser = (userId: string, access: Access, targetObject: Permissioned) => {
-    if (targetObject.permission.accessItems) {
+export const isAllowedToUser = (user: User, targetObject: Permissioned, access: Access) => {
+    if (targetObject.permission && targetObject.permission.accessItems) {
         const accessItems = targetObject.permission.accessItems;
         for (let i = 0; i < accessItems.length; i++) {
-            if (accessItems[i].subjectId === userId && accessItems[i].access >= access) {
+            if (accessItems[i].access < access) {
+                continue;
+            }
+            if (accessItems[i].subjectId === user.id) {
                 return true;
+            }
+            if (user.teams) {
+                for (let j = 0; j < user.teams.length; j++) {
+                    if (accessItems[i].subjectId === user.teams[j].id) {
+                        return true;
+                    }
+                }
             }
         }
     }
 
-    if (targetObject.permission.inheritParents && targetObject.parent) {
-        return isAllowedToUser(userId, access, targetObject.parent);
+    if (targetObject.permission && targetObject.permission.inheritParents && targetObject.parent) {
+        return isAllowedToUser(user, targetObject.parent, access);
     }
 
     return false;

--- a/src/common/access.ts
+++ b/src/common/access.ts
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * This set of utility functions collects allowed subjects/actions in the vertical hierarchy of a requested object
+ * to determine if the user has a permission to perform an action to the object. 
+ */
+
+import { Permissioned, Access } from '../model/entity/permissioned/base';
+
+export const isAllowedToUser = (userId: string, access: Access, targetObject: Permissioned) => {
+    if (targetObject.permission.accessItems) {
+        const accessItems = targetObject.permission.accessItems;
+        for (let i = 0; i < accessItems.length; i++) {
+            if (accessItems[i].subjectId === userId && accessItems[i].access >= access) {
+                return true;
+            }
+        }
+    }
+
+    if (targetObject.permission.inheritParents && targetObject.parent) {
+        return isAllowedToUser(userId, access, targetObject.parent);
+    }
+
+    return false;
+};

--- a/src/handler/common.ts
+++ b/src/handler/common.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { Deck, getOneById as getDeckById, getAll as getAllDecks } from '../model/deck';
+import { Team, getOneById as getTeamById } from '../model/team';
 
 export async function createEntity(entity: string, userId: string, payload: Object): Promise<Object> {
   const obj = await getNewObject(entity, userId, payload);
@@ -21,10 +22,12 @@ export function getAll(entity: string, userId: string, cascade: boolean = false)
   }
 }
 
-export async function getOneById(entity: string, userId: string, objId: string, cascade: boolean = false): Promise<Deck> {
+export async function getOneById(entity: string, userId: string, objId: string, cascade: boolean = false): Promise<Deck | Team> {
   switch (entity) {
     case 'deck':
       return await getDeckById(userId, objId);
+    case 'team':
+      return await getTeamById(userId, objId);
   }
 }
 
@@ -33,12 +36,14 @@ async function getNewObject(entity: string, userId: string, payload: any): Promi
   switch (entity) {
     case 'deck':
       obj = new Deck();
-      await obj.init(userId, payload);
+    case 'team':
+      obj = new Team();
   }
+  await obj.init(userId, payload);
   return obj;
 }
 
 export async function deleteEntityById(entity: string, userId: string, objId: string): Promise<void> {
-  const obj: Deck = await getOneById(entity, userId, objId);
+  const obj: Deck | Team = await getOneById(entity, userId, objId);
   obj.delete();
 }

--- a/src/handler/common.ts
+++ b/src/handler/common.ts
@@ -27,7 +27,7 @@ export async function getOneById(entity: string, userId: string, objId: string, 
     case 'deck':
       return await getDeckById(userId, objId);
     case 'team':
-      return await getTeamById(userId, objId);
+      return await getTeamById(objId);
   }
 }
 
@@ -36,8 +36,10 @@ async function getNewObject(entity: string, userId: string, payload: any): Promi
   switch (entity) {
     case 'deck':
       obj = new Deck();
+      break;
     case 'team':
       obj = new Team();
+      break;
   }
   await obj.init(userId, payload);
   return obj;

--- a/src/handler/common.ts
+++ b/src/handler/common.ts
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 import { Deck, getOneById as getDeckById, getAll as getAllDecks } from '../model/deck';
 

--- a/src/model/deck.ts
+++ b/src/model/deck.ts
@@ -8,8 +8,7 @@ import { getStrmToken } from '../common/strm';
 
 import { connection } from '../database';
 import { Deck as Entity } from './entity/deck';
-import { User as UserEntity } from './entity/user';
-import { getOneById as getUserById } from './user';
+import { User, getOneById as getUserById } from './user';
 
 const DEFAULT_SLIDES = [];
 const DEFAULT_CURRENT_SLIDE = 0;
@@ -18,7 +17,7 @@ export class Deck {
   id: string;
   strmId: string;
   strmPatchKey: string;
-  owner: UserEntity;
+  owner: User;
   slides: string[];
   currentSlide: number;
   dbObject: Entity;
@@ -62,7 +61,7 @@ export class Deck {
     this.dbObject = dbObject;
     this.id = dbObject.id;
     if (dbObject.owner) {
-      this.owner = dbObject.owner;
+      this.owner = new User(dbObject.owner);
     }
     if (dbObject.strmId) {
       this.strmId = dbObject.strmId;
@@ -81,14 +80,14 @@ export class Deck {
   async setPropertiesFromPayload(userId: string, payload: any) {
     const owner = await getUserById(payload.owner);
 
-    this.owner = owner.dbObject;
+    this.owner = owner;
     this.slides = payload.slides ? payload.slides : DEFAULT_SLIDES;
     this.currentSlide = payload.currentSlide || DEFAULT_CURRENT_SLIDE;
   }
 
   save(): Promise<Object> {
     return connection.then((conn: Connection) => {
-      this.dbObject.owner = this.owner;
+      this.dbObject.owner = this.owner.dbObject;
       this.dbObject.strmId = this.strmId;
       this.dbObject.strmPatchKey = this.strmPatchKey;
       this.dbObject.slides = this.slides;

--- a/src/model/deck.ts
+++ b/src/model/deck.ts
@@ -23,8 +23,12 @@ export class Deck {
   currentSlide: number;
   dbObject: Entity;
 
-  constructor() {
-    this.dbObject = new Entity();
+  constructor(dbObject?: Entity) {
+    if (dbObject) {
+      this.setPropertiesFromDbObject(dbObject);
+    } else {
+      this.dbObject = new Entity();
+    }
   }
 
   async init(userId, payload) {
@@ -100,7 +104,11 @@ export class Deck {
       return;
     }
 
-    await conn.manager.remove(this.dbObject);
+    try {
+      await conn.manager.remove(this.dbObject);
+    } catch (ex) {
+      console.log(`Error deleting a deck ${this.id}`);
+    }
   }
 }
 

--- a/src/model/entity/deck.ts
+++ b/src/model/entity/deck.ts
@@ -1,8 +1,11 @@
+'use strict';
+
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { Permissioned } from './permissioned/base';
 import { User } from './user';
 
 @Entity()
-export class Deck {
+export class Deck extends Permissioned {
 
     @PrimaryGeneratedColumn("uuid")
     id: string;
@@ -22,4 +25,8 @@ export class Deck {
 
     @Column()
     currentSlide: number;
+
+    // We don't have the object hierarchy just yet.
+    // @ManyToOne(() => DeckList, deckList => deckList.decks)
+    // parent: DeckList;
 }

--- a/src/model/entity/permissioned/base.ts
+++ b/src/model/entity/permissioned/base.ts
@@ -7,13 +7,15 @@ export enum Access {
     Write
 }
 
-type AccessItem = {
-    subjectType: string;
+export type SubjectType = 'TEAM' | 'USER';
+
+export type AccessItem = {
+    subjectType: SubjectType;
     subjectId: string;
     access: Access;
 };
 
-type Permission = {
+export type Permission = {
     inheritParents?: boolean;
     accessItems?: AccessItem[];
 };

--- a/src/model/entity/permissioned/base.ts
+++ b/src/model/entity/permissioned/base.ts
@@ -1,0 +1,36 @@
+'use strict';
+
+import { Column, ValueTransformer } from 'typeorm';
+
+export enum Access {
+    Read = 1,
+    Write
+}
+
+type AccessItem = {
+    subjectType: string;
+    subjectId: string;
+    access: Access;
+};
+
+type Permission = {
+    inheritParents?: boolean;
+    accessItems?: AccessItem[];
+};
+
+class PermissionTransformer implements ValueTransformer {
+    to(value: Permission): string {
+        return JSON.stringify(value);
+    }
+
+    from(value: string): Permission {
+        return JSON.parse(value);
+    }
+}
+
+export class Permissioned {
+    @Column({ type: String, transformer: new PermissionTransformer(), nullable: true })
+    permission: Permission;
+
+    parent: Permissioned;
+}

--- a/src/model/entity/team.ts
+++ b/src/model/entity/team.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, ManyToMany, JoinTable } from 'typeorm';
 import { User } from './user';
 
 @Entity()
@@ -12,7 +12,10 @@ export class Team {
     @Column()
     description: string;
 
-    @ManyToMany(() => User)
+    @ManyToOne(() => User, user => user.teamsOwned)
+    owner: User;
+
+    @ManyToMany(() => User, user => user.teams)
     @JoinTable()
     members: User[];
 }

--- a/src/model/entity/team.ts
+++ b/src/model/entity/team.ts
@@ -1,0 +1,18 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable } from 'typeorm';
+import { User } from './user';
+
+@Entity()
+export class Team {
+    @PrimaryGeneratedColumn("uuid")
+    id: string;
+
+    @Column()
+    name: string;
+
+    @Column()
+    description: string;
+
+    @ManyToMany(() => User)
+    @JoinTable()
+    members: User[];
+}

--- a/src/model/entity/user.ts
+++ b/src/model/entity/user.ts
@@ -1,5 +1,6 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToMany, JoinTable } from 'typeorm';
 import { Deck } from './deck';
+import { Team } from './team';
 
 @Entity()
 export class User {
@@ -17,4 +18,8 @@ export class User {
 
     @OneToMany(() => Deck, deck => deck.owner)
     decks: Deck[];
+
+    @ManyToMany(() => Team)
+    @JoinTable()
+    teams: Team[];
 }

--- a/src/model/entity/user.ts
+++ b/src/model/entity/user.ts
@@ -19,7 +19,11 @@ export class User {
     @OneToMany(() => Deck, deck => deck.owner)
     decks: Deck[];
 
-    @ManyToMany(() => Team)
-    @JoinTable()
+    // Teams that the user "owns"
+    @OneToMany(() => Team, team => team.owner)
+    teamsOwned: Team[];
+
+    // Teams the user "belongs to"
+    @ManyToMany(() => Team, team => team.members)
     teams: Team[];
 }

--- a/src/model/team.ts
+++ b/src/model/team.ts
@@ -1,0 +1,62 @@
+'use strict';
+
+import { connection } from '../database';
+import { Team as Entity } from './entity/team';
+
+export class Team {
+  id: string;
+  name: string;
+  description: string;
+  dbObject: Entity;
+
+  constructor(dbObject?: Entity) {
+    if (dbObject) {
+      this.setPropertiesFromDbObject(dbObject);
+    } else {
+      this.dbObject = new Entity();
+    }
+  }
+
+  setPropertiesFromDbObject(dbObject: Entity) {
+    this.dbObject = dbObject;
+    this.id = dbObject.id;
+    if (dbObject.name) {
+      this.name = dbObject.name;
+    }
+    if (dbObject.description) {
+      this.description = dbObject.description;
+    }
+  }
+
+  setPropertiesFromPayload(payload: any) {
+    this.name = payload.name;
+    this.description = payload.description;
+  }
+
+  async save(): Promise<Entity> {
+    const conn = await connection;
+    if (!conn) {
+      return null;
+    }
+
+    this.dbObject.name = this.name;
+    this.dbObject.description = this.description;
+    return await conn.manager.save(this.dbObject);
+  }
+}
+
+export async function getOneById(teamId: string): Promise<Team> {
+  const conn = await connection;
+  if (!conn) {
+    return null;
+  }
+
+  const dbObject = await conn.manager.findOne(Entity, teamId);
+  if (!dbObject) {
+    return null;
+  }
+
+  let obj = new Team();
+  obj.setPropertiesFromDbObject(dbObject);
+  return obj;
+}

--- a/src/model/team.ts
+++ b/src/model/team.ts
@@ -33,7 +33,6 @@ export class Team {
     if (dbObject.description) {
       this.description = dbObject.description;
     }
-    console.log(dbObject.owner);
     if (dbObject.owner) {
       this.owner = new User(dbObject.owner);
     }

--- a/src/model/team.ts
+++ b/src/model/team.ts
@@ -78,12 +78,7 @@ export class Team {
     }
   }
 
-  async addNewMember(newMember: User): Promise<Team> {
-    const conn = await connection;
-    if(!conn) {
-      return null;
-    }
-  
+  addNewMember(newMember: User): void {
     if (!this.members) {
       this.members = [];
     }
@@ -91,7 +86,7 @@ export class Team {
     for (let i = 0; i < this.members.length; i++) {
       if (this.members[i].id === newMember.id) {
         // The user is already included in the team
-        return null;
+        return;
       }
     }
 
@@ -99,7 +94,7 @@ export class Team {
   }
 }
 
-export async function getOneById(userId: string, teamId: string): Promise<Team> {
+export async function getOneById(teamId: string): Promise<Team> {
   const conn = await connection;
   if (!conn) {
     return null;

--- a/src/model/user.ts
+++ b/src/model/user.ts
@@ -36,7 +36,6 @@ export class User {
     if (dbObject.decks) {
       this.decks = dbObject.decks.map(dbDeckObject => new Deck(dbDeckObject));
     }
-    console.log(dbObject.teams);
     if (dbObject.teams) {
       this.teams = dbObject.teams.map(dbTeamObject => new Team(dbTeamObject));
     }

--- a/src/model/user.ts
+++ b/src/model/user.ts
@@ -16,8 +16,12 @@ export class User {
   teams: Team[];
   dbObject: Entity;
 
-  constructor() {
-    this.dbObject = new Entity();
+  constructor(dbObject?: Entity) {
+    if (dbObject) {
+      this.setPropertiesFromDbObject(dbObject);
+    } else {
+      this.dbObject = new Entity();
+    }
   }
 
   setPropertiesFromDbObject(dbObject: Entity) {
@@ -32,6 +36,7 @@ export class User {
     if (dbObject.decks) {
       this.decks = dbObject.decks.map(dbDeckObject => new Deck(dbDeckObject));
     }
+    console.log(dbObject.teams);
     if (dbObject.teams) {
       this.teams = dbObject.teams.map(dbTeamObject => new Team(dbTeamObject));
     }

--- a/src/route/api.ts
+++ b/src/route/api.ts
@@ -2,10 +2,26 @@
 
 import { Response, Request, Router } from 'express';
 import { basicRouterFactory } from './basic';
-import { createEntity, getOneById } from '../handler/common';
-// import { Deck } from '../model/deck';
+import { getOneById as getTeamById } from '../model/team';
+import { getOneById as getUserById } from '../model/user';
 
 export const router = new Router();
 
 const deckRouter = basicRouterFactory('deck');
 router.use('/deck', deckRouter);
+
+const teamRouter = basicRouterFactory('team');
+teamRouter.post('/:teamId/member/:userId', async (req: Request, res: Response) => {
+    const team = await getTeamById(req.user.id, req.params['teamId']);
+    console.log(team);
+    const user = await getUserById(req.params['userId']);
+
+    team.addNewMember(user);
+    
+    const saved = await team.save();
+    res.status(202).json({
+        data: saved
+    });
+});
+
+router.use('/team', teamRouter);

--- a/src/route/api.ts
+++ b/src/route/api.ts
@@ -4,16 +4,38 @@ import { Response, Request, Router } from 'express';
 import { basicRouterFactory } from './basic';
 import { getOneById as getTeamById } from '../model/team';
 import { getOneById as getUserById } from '../model/user';
+import { getOneById as getDeckById } from '../model/deck';
 
 export const router = new Router();
 
 const deckRouter = basicRouterFactory('deck');
+deckRouter.post('/:deckId/grant/:subjectId', async (req: Request, res: Response) => {
+    const owner = await getUserById(req.user.id);
+    const deck = await getDeckById(req.user.id, req.params['deckId']);
+
+    // Check if the owner is really the owner of the deck
+    if (owner.id !== deck.owner.id) {
+        res.status(403).json({});
+        return;
+    }
+
+    if (typeof(req.body.access) !== 'number' || (req.body.access !== 0 && req.body.access !== 1)) {
+        res.status(400).json({});
+    }
+
+    await deck.grantAccess(req.params['subjectId'], req.body.access);
+
+    const saved = await deck.save();
+    res.status(202).json({
+        data: saved
+    });
+});
+
 router.use('/deck', deckRouter);
 
 const teamRouter = basicRouterFactory('team');
 teamRouter.post('/:teamId/member/:userId', async (req: Request, res: Response) => {
-    const team = await getTeamById(req.user.id, req.params['teamId']);
-    console.log(team);
+    const team = await getTeamById(req.params['teamId']);
     const user = await getUserById(req.params['userId']);
 
     team.addNewMember(user);

--- a/src/route/auth.ts
+++ b/src/route/auth.ts
@@ -4,7 +4,8 @@ import { Response, Request, Router } from 'express';
 import { AUTH } from '../common/config';
 import { pluckDbObject } from '../common/helpers';
 import { authenticate } from '../middleware/auth/password';
-import { User } from '../model/user';
+import { authenticateJwt } from '../middleware/auth';
+import { User, getOneById as getUserById } from '../model/user';
 
 
 export const router = new Router();
@@ -50,4 +51,9 @@ router.post('/user', async (req: Request, res: Response) => {
   res.status(202).json({
     data: saved
   });
+});
+
+router.get('/user/:userId', authenticateJwt, async (req: Request, res: Response) => {
+  const user = await getUserById(req.params['userId']);
+  res.status(200).send(user);
 });

--- a/src/wss.ts
+++ b/src/wss.ts
@@ -18,6 +18,7 @@ wsServer.on('connection', async (ws, request, client) => {
     ws.send('Socket open');
     const params = parseUrlQueryParams(request.url);
     const deckId = params['deck_id'];
+    // TODO: get token instead of user_id, then look up user_id based on the token.
     const userId = params['user_id'];
     if (!deckId || !userId) {
         ws.close();


### PR DESCRIPTION
The main objective is to implement team/individual level access control. This will eventually be extended to access control over layered resources (Deck list -> Deck, for example)

As of now, it is supposed to be able to handle existing relation between users and team, if there's any. For this functionality to be effective, we additionally need to:

1. Implement team APIs so new teams can be added. An endpoint will be added to add an existing user to a group as a member.
2. (Optional) For now, the owner of the team will have a permission to edit the team, which includes adding new members. Going forward, we want to implement "roles" in the teams (Owner, Admin, ...)

Once we have the mechanism to create and update team-user relations, we can go ahead and complete this feature. All this will be implemented in this one PR.

See these docs for more context:
https://drive.google.com/file/d/1k0Vv5LvLErehIt01uDeQ4E3wTwadD2yW/view?usp=sharing
https://drive.google.com/file/d/1O9vjCjh6rv1s28Tlg-pc57BcN5EMzBjN/view?usp=sharing

[Acceptance Criteria/Testing Scenario](https://github.com/seond/sncd-api/files/7316720/ac.txt)
